### PR TITLE
Fix stop criterion for design-multistate if no sequences can be found

### DIFF
--- a/scripts/design-multistate.py
+++ b/scripts/design-multistate.py
@@ -212,7 +212,7 @@ def BalancedSamples(structures, target_energies, offsets, args, energy_step=0.5)
         if (args.debug):
             print('# Stop: ', abs(np.mean(eos)-target_energy))
             print("# Already found: ", len(BalancedSample)/float(args.number)*100, "%")
-        if (abs(abs(np.mean(eos)-target_energy)) > energy_step) or len(BalancedSample) > args.number:
+        if abs(np.mean(eos)-target_energy) > energy_step or len(BalancedSample) > args.number:
             break
     return BalancedSample
 


### PR DESCRIPTION
Fixes an edge case when no Admissible Sequences could be found and redefines the Stop criterion for this case. The script should always terminate now.